### PR TITLE
ignore link-local address

### DIFF
--- a/dnssrv/dnssrv.go
+++ b/dnssrv/dnssrv.go
@@ -78,8 +78,10 @@ func getIfaceAddrs(iface string) []net.IP {
 			if err != nil {
 				continue
 			}
-			log.Debugf("Found address: %s", ip.String())
-			retaddrs = append(retaddrs, ip)
+			if !ip.IsLinkLocalUnicast() {
+				log.Debugf("Found address: %s", ip.String())
+				retaddrs = append(retaddrs, ip)
+			}
 		}
 		return retaddrs
 	}


### PR DESCRIPTION
Resolves #1. On linux binding to a link-local address fails, so skip them.