### PR TITLE
Fixing Viper config parsing logic

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,11 +45,12 @@ func init() {
 func initConfig() {
 	if cfgFile != "" { // enable ability to specify config file via flag
 		viper.SetConfigFile(cfgFile)
+	} else {
+		viper.SetConfigName(".ztdns") // name of config file (without extension)
+		viper.AddConfigPath(".")      // adding current directory as first search path
+		viper.AddConfigPath("$HOME")  // adding home directory as second search path
+		}
 	}
-
-	viper.SetConfigName(".ztdns") // name of config file (without extension)
-	viper.AddConfigPath(".")      // adding current directory as first search path
-	viper.AddConfigPath("$HOME")  // adding home directory as second search path
 
 	viper.SetEnvPrefix("ztdns")
 	viper.AutomaticEnv() // read in environment variables that match


### PR DESCRIPTION
Basically, current code ignores non-default config path since config settings are getting overrode. This PR is meant fix this issue.